### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thank you for the interest in contributing! 
+
+We'd appreciate [issue reports](https://github.com/nrfrank/bisi/issues) if you run into trouble using bisi.
+
+If you'd like to contribute to bisi be sure to open an issue and create a pull request so that we can discuss and review it.
+
+
+# Community
+
+Everyone is welcome to join us in our [slack channel](https://join.slack.com/t/pytugboat/shared_invite/zt-13htnt06d-auAFpknLVQzMdoSdi2C18g)!
+
+Please maintain appropriate, professional conduct while participating in our community. This includes all channels of
+communication. 


### PR DESCRIPTION
@nrfrank Are you able to replace that slack invitation link with a permanent one? Slack says that link will expire in 30 days.